### PR TITLE
some improvements

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -157,6 +157,8 @@ pub const Linenoise = struct {
     history: History,
     multiline_mode: bool = false,
     mask_mode: bool = false,
+    is_tty: bool = false,
+    term_supported: bool = false,
     hints_callback: ?HintsCallback = null,
     completions_callback: ?CompletionsCallback = null,
 
@@ -164,10 +166,12 @@ pub const Linenoise = struct {
 
     /// Initialize a linenoise struct
     pub fn init(allocator: Allocator) Self {
-        return Self{
+        var self = Self{
             .allocator = allocator,
             .history = History.empty(allocator),
         };
+        self.examineStdIo();
+        return self;
     }
 
     /// Free all resources occupied by this struct
@@ -175,21 +179,28 @@ pub const Linenoise = struct {
         self.history.deinit();
     }
 
+    /// Re-examine (currently) stdin and environment variables to
+    /// check if line editing and prompt printing should be
+    /// enabled or not.
+    pub fn examineStdIo(self: *Self) void {
+        const stdin_file = std.io.getStdIn();
+        self.is_tty = stdin_file.isTty();
+        self.term_supported = !isUnsupportedTerm();
+    }
+
     /// Reads a line from the terminal. Caller owns returned memory
     pub fn linenoise(self: *Self, prompt: []const u8) !?[]const u8 {
         const stdin_file = std.io.getStdIn();
         const stdout_file = std.io.getStdOut();
 
-        if (stdin_file.isTty()) {
-            if (isUnsupportedTerm()) {
-                try stdout_file.writeAll(prompt);
-                return try linenoiseNoTTY(self.allocator, stdin_file);
-            } else {
-                return try linenoiseRaw(self, stdin_file, stdout_file, prompt);
-            }
-        } else {
-            return try linenoiseNoTTY(self.allocator, stdin_file);
+        if (self.is_tty and !self.term_supported) {
+            try stdout_file.writeAll(prompt);
         }
+
+        return try if (self.is_tty and self.term_supported)
+            linenoiseRaw(self, stdin_file, stdout_file, prompt)
+        else
+            linenoiseNoTTY(self.allocator, stdin_file);
     }
 };
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -155,10 +155,10 @@ fn linenoiseNoTTY(allocator: Allocator, stdin: File) !?[]const u8 {
 pub const Linenoise = struct {
     allocator: Allocator,
     history: History,
-    multiline_mode: bool,
-    mask_mode: bool,
-    hints_callback: ?HintsCallback,
-    completions_callback: ?CompletionsCallback,
+    multiline_mode: bool = false,
+    mask_mode: bool = false,
+    hints_callback: ?HintsCallback = null,
+    completions_callback: ?CompletionsCallback = null,
 
     const Self = @This();
 
@@ -167,10 +167,6 @@ pub const Linenoise = struct {
         return Self{
             .allocator = allocator,
             .history = History.empty(allocator),
-            .mask_mode = false,
-            .multiline_mode = false,
-            .hints_callback = null,
-            .completions_callback = null,
         };
     }
 


### PR DESCRIPTION
Cache some syscalls (and env check) and declare default values in an imo better way.

Justification for caching: these values change really rarely, but one of them introduces a syscall, which makes `strace`'s of programs using this a bit more annoying to read. I also think that allowing the user to override them is a good idea (in case the user encounters additional broken terminals but doesn't want to patch this package).

The last changed section is mostly a style change, but I found this variant easier to understand.