### PR TITLE
update @clz and function callbacks for 0.10; make linenoiseX functions

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -39,7 +39,7 @@ pub fn build(b: *Builder) void {
 
     // C example
     var c_example = b.addExecutable("example", "examples/example.c");
-    c_example.addIncludeDir("include");
+    c_example.addIncludePath("include");
     c_example.linkLibC();
     c_example.linkLibrary(lib);
     c_example.setTarget(target);

--- a/src/c.zig
+++ b/src/c.zig
@@ -26,9 +26,9 @@ const LinenoiseCompletions = extern struct {
     }
 };
 
-const linenoiseCompletionCallback = fn ([*:0]const u8, *LinenoiseCompletions) callconv(.C) void;
-const linenoiseHintsCallback = fn ([*:0]const u8, *c_int, *c_int) callconv(.C) ?[*:0]u8;
-const linenoiseFreeHintsCallback = fn (*anyopaque) callconv(.C) void;
+const linenoiseCompletionCallback = std.meta.FnPtr(fn ([*:0]const u8, *LinenoiseCompletions) callconv(.C) void);
+const linenoiseHintsCallback = std.meta.FnPtr(fn ([*:0]const u8, *c_int, *c_int) callconv(.C) ?[*:0]u8);
+const linenoiseFreeHintsCallback = std.meta.FnPtr(fn (*anyopaque) callconv(.C) void);
 
 export fn linenoiseSetCompletionCallback(fun: linenoiseCompletionCallback) void {
     c_completion_callback = fun;

--- a/src/main.zig
+++ b/src/main.zig
@@ -11,8 +11,8 @@ const enableRawMode = term.enableRawMode;
 const disableRawMode = term.disableRawMode;
 const getColumns = term.getColumns;
 
-pub const HintsCallback = *fn (Allocator, []const u8) Allocator.Error!?[]const u8;
-pub const CompletionsCallback = *fn (Allocator, []const u8) Allocator.Error![]const []const u8;
+pub const HintsCallback = std.meta.FnPtr(fn (Allocator, []const u8) Allocator.Error!?[]const u8);
+pub const CompletionsCallback = std.meta.FnPtr(fn (Allocator, []const u8) Allocator.Error![]const []const u8);
 
 const key_null = 0;
 const key_ctrl_a = 1;

--- a/src/main.zig
+++ b/src/main.zig
@@ -11,8 +11,8 @@ const enableRawMode = term.enableRawMode;
 const disableRawMode = term.disableRawMode;
 const getColumns = term.getColumns;
 
-pub const HintsCallback = (fn (Allocator, []const u8) Allocator.Error!?[]const u8);
-pub const CompletionsCallback = (fn (Allocator, []const u8) Allocator.Error![]const []const u8);
+pub const HintsCallback = *fn (Allocator, []const u8) Allocator.Error!?[]const u8;
+pub const CompletionsCallback = *fn (Allocator, []const u8) Allocator.Error![]const []const u8;
 
 const key_null = 0;
 const key_ctrl_a = 1;
@@ -34,7 +34,7 @@ const key_ctrl_w = 23;
 const key_esc = 27;
 const key_backspace = 127;
 
-fn linenoiseEdit(ln: *Linenoise, in: File, out: File, prompt: []const u8) !?[]const u8 {
+pub fn linenoiseEdit(ln: *Linenoise, in: File, out: File, prompt: []const u8) !?[]const u8 {
     var state = LinenoiseState.init(ln, in, out, prompt);
     defer state.buf.deinit(state.allocator);
 
@@ -133,7 +133,7 @@ fn linenoiseEdit(ln: *Linenoise, in: File, out: File, prompt: []const u8) !?[]co
 
 /// Read a line with custom line editing mechanics. This includes hints,
 /// completions and history
-fn linenoiseRaw(ln: *Linenoise, in: File, out: File, prompt: []const u8) !?[]const u8 {
+pub fn linenoiseRaw(ln: *Linenoise, in: File, out: File, prompt: []const u8) !?[]const u8 {
     defer out.writeAll("\n") catch {};
 
     const orig = try enableRawMode(in);
@@ -143,7 +143,7 @@ fn linenoiseRaw(ln: *Linenoise, in: File, out: File, prompt: []const u8) !?[]con
 }
 
 /// Read a line with no special features (no hints, no completions, no history)
-fn linenoiseNoTTY(allocator: Allocator, stdin: File) !?[]const u8 {
+pub fn linenoiseNoTTY(allocator: Allocator, stdin: File) !?[]const u8 {
     var reader = stdin.reader();
     const max_line_len = std.math.maxInt(usize);
     return reader.readUntilDelimiterAlloc(allocator, '\n', max_line_len) catch |e| switch (e) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -34,7 +34,7 @@ const key_ctrl_w = 23;
 const key_esc = 27;
 const key_backspace = 127;
 
-pub fn linenoiseEdit(ln: *Linenoise, in: File, out: File, prompt: []const u8) !?[]const u8 {
+fn linenoiseEdit(ln: *Linenoise, in: File, out: File, prompt: []const u8) !?[]const u8 {
     var state = LinenoiseState.init(ln, in, out, prompt);
     defer state.buf.deinit(state.allocator);
 
@@ -133,7 +133,7 @@ pub fn linenoiseEdit(ln: *Linenoise, in: File, out: File, prompt: []const u8) !?
 
 /// Read a line with custom line editing mechanics. This includes hints,
 /// completions and history
-pub fn linenoiseRaw(ln: *Linenoise, in: File, out: File, prompt: []const u8) !?[]const u8 {
+fn linenoiseRaw(ln: *Linenoise, in: File, out: File, prompt: []const u8) !?[]const u8 {
     defer out.writeAll("\n") catch {};
 
     const orig = try enableRawMode(in);
@@ -143,7 +143,7 @@ pub fn linenoiseRaw(ln: *Linenoise, in: File, out: File, prompt: []const u8) !?[
 }
 
 /// Read a line with no special features (no hints, no completions, no history)
-pub fn linenoiseNoTTY(allocator: Allocator, stdin: File) !?[]const u8 {
+fn linenoiseNoTTY(allocator: Allocator, stdin: File) !?[]const u8 {
     var reader = stdin.reader();
     const max_line_len = std.math.maxInt(usize);
     return reader.readUntilDelimiterAlloc(allocator, '\n', max_line_len) catch |e| switch (e) {

--- a/src/state.zig
+++ b/src/state.zig
@@ -177,7 +177,8 @@ pub const LinenoiseState = struct {
 
                     // Restore original buffer into state
                     self.buf.deinit(self.allocator);
-                    self.buf = ArrayList(u8).fromOwnedSlice(self.allocator, old_buf).moveToUnmanaged();
+                    var new_buf = ArrayList(u8).fromOwnedSlice(self.allocator, old_buf);
+                    self.buf = new_buf.moveToUnmanaged();
                     self.pos = old_pos;
                 } else {
                     // Return to original line
@@ -423,13 +424,13 @@ pub const LinenoiseState = struct {
     }
 
     fn prevCodepointLen(self: *Self, pos: usize) usize {
-        if (pos >= 1 and @clz(u8, ~self.buf.items[pos - 1]) == 0) {
+        if (pos >= 1 and @clz(~self.buf.items[pos - 1]) == 0) {
             return 1;
-        } else if (pos >= 2 and @clz(u8, ~self.buf.items[pos - 2]) == 2) {
+        } else if (pos >= 2 and @clz(~self.buf.items[pos - 2]) == 2) {
             return 2;
-        } else if (pos >= 3 and @clz(u8, ~self.buf.items[pos - 3]) == 3) {
+        } else if (pos >= 3 and @clz(~self.buf.items[pos - 3]) == 3) {
             return 3;
-        } else if (pos >= 4 and @clz(u8, ~self.buf.items[pos - 4]) == 4) {
+        } else if (pos >= 4 and @clz(~self.buf.items[pos - 4]) == 4) {
             return 4;
         } else {
             return 0;


### PR DESCRIPTION
It looks like linenoize doesn't compile with the current zig version, so I fixed some compilation errors.

I also made some functions public that seem like they should be, unsure if this is the intention of them originally