### PR TITLE
Move to Zig modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/zig-wcwidth"]
-	path = src/zig-wcwidth
-	url = https://github.com/joachimschmidt557/zig-wcwidth

--- a/build.zig
+++ b/build.zig
@@ -45,7 +45,6 @@ pub fn build(b: *Build) void {
         .target = target,
         .optimize = optimize,
     });
-    main_tests.addModule("wcwidth", wcwidth.module("wcwidth"));
     const test_step = b.step("test", "Run library tests");
     test_step.dependOn(&main_tests.step);
 

--- a/build.zig
+++ b/build.zig
@@ -12,13 +12,19 @@ pub fn build(b: *Build) void {
     // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
     const optimize = b.standardOptimizeOption(.{});
 
-    _ = b.addModule("linenoise", .{
-        .source_file = .{ .path = "src/main.zig" },
-    });
-
     const wcwidth = b.dependency("wcwidth", .{
         .target = target,
         .optimize = optimize,
+    });
+
+    _ = b.addModule("linenoise", .{
+        .source_file = .{ .path = "src/main.zig" },
+        .dependencies = &.{
+            .{
+                .name = "wcwidth",
+                .module = wcwidth.module("wcwidth"),
+            },
+        },
     });
 
     // Static library

--- a/build.zig
+++ b/build.zig
@@ -17,7 +17,7 @@ pub fn build(b: *Build) void {
         .optimize = optimize,
     });
 
-    _ = b.addModule("linenoise", .{
+    const linenoise = b.addModule("linenoise", .{
         .source_file = .{ .path = "src/main.zig" },
         .dependencies = &.{
             .{
@@ -45,7 +45,7 @@ pub fn build(b: *Build) void {
         .target = target,
         .optimize = optimize,
     });
-
+    main_tests.addModule("wcwidth", wcwidth.module("wcwidth"));
     const test_step = b.step("test", "Run library tests");
     test_step.dependOn(&main_tests.step);
 
@@ -56,9 +56,7 @@ pub fn build(b: *Build) void {
         .target = target,
         .optimize = optimize,
     });
-    example.addAnonymousModule("linenoise", .{
-        .source_file = FileSource.relative("src/main.zig"),
-    });
+    example.addModule("linenoise", linenoise);
 
     var example_run = example.run();
 

--- a/build.zig
+++ b/build.zig
@@ -11,6 +11,10 @@ pub fn build(b: *Build) void {
     // Standard release options allow the person running `zig build` to select
     // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
     const optimize = b.standardOptimizeOption(.{});
+    
+    _ = b.addModule("linenoise", .{
+        .source_file = .{ .path = "src/main.zig" },
+    });
 
     // Static library
     const lib = b.addStaticLibrary(.{

--- a/build.zig
+++ b/build.zig
@@ -11,9 +11,14 @@ pub fn build(b: *Build) void {
     // Standard release options allow the person running `zig build` to select
     // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
     const optimize = b.standardOptimizeOption(.{});
-    
+
     _ = b.addModule("linenoise", .{
         .source_file = .{ .path = "src/main.zig" },
+    });
+
+    const wcwidth = b.dependency("wcwidth", .{
+        .target = target,
+        .optimize = optimize,
     });
 
     // Static library
@@ -23,6 +28,7 @@ pub fn build(b: *Build) void {
         .target = target,
         .optimize = optimize,
     });
+    lib.addModule("wcwidth", wcwidth.module("wcwidth"));
     lib.linkLibC();
     lib.install();
 
@@ -55,7 +61,7 @@ pub fn build(b: *Build) void {
 
     // C example
     var c_example = b.addExecutable(.{
-        .name =  "example",
+        .name = "example",
         .root_source_file = FileSource.relative("examples/example.c"),
         .target = target,
         .optimize = optimize,

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "0.1.0",
     .dependencies = .{
         .wcwidth = .{
-            .url = "https://github.com/Jengamon/zig-wcwidth/archive/42de26e5612ce9b86fffe882dc552ce63c59e521.tar.gz",
-            .hash = "1220eb67f8265fb314bbb2a27f3ccff51d16f53fcb006be4288e151e3ac4491ffa10",
+            .url = "https://github.com/joachimschmidt557/zig-wcwidth/archive/f7296a31e83fe26240137404b56e64b9997afe04.tar.gz",
+            .hash = "12208294054b53630bc7a693cf2d8be329b434350986575b30f1ca657b982498f9a3",
         },
     },
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,10 @@
+.{
+    .name = "linenoise",
+    .version = "0.1.0",
+    .dependencies = .{
+        .wcwidth = .{
+            .url = "https://github.com/Jengamon/zig-wcwidth/archive/42de26e5612ce9b86fffe882dc552ce63c59e521.tar.gz",
+            .hash = "1220eb67f8265fb314bbb2a27f3ccff51d16f53fcb006be4288e151e3ac4491ffa10",
+        },
+    },
+}

--- a/src/unicode.zig
+++ b/src/unicode.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const expectEqualSlices = std.testing.expectEqualSlices;
 
-const wcwidth = @import("zig-wcwidth/src/main.zig").wcwidth;
+const wcwidth = @import("wcwidth").wcwidth;
 
 pub fn width(s: []const u8) usize {
     var result: usize = 0;


### PR DESCRIPTION
Relies on https://github.com/joachimschmidt557/zig-wcwidth/pull/3
But moves this repo to the new modules code organization style

Not sure if libraries should commit build.zig.zon. And it would need to be updated anyways if the other PR is merged.

EDIT: I think that yeah, libraries also need build.zig.zon files, as the example libraries linked [here](https://github.com/ziglang/zig/pull/14265) also have them.