### PR TITLE
remove duplicate symbol

### DIFF
--- a/src/term.zig
+++ b/src/term.zig
@@ -20,7 +20,6 @@ pub fn isUnsupportedTerm(allocator: std.mem.Allocator) bool {
 
 const w = struct {
     pub usingnamespace std.os.windows;
-    pub const ENABLE_VIRTUAL_TERMINAL_PROCESSING = @as(c_int, 0x4);
     pub const ENABLE_VIRTUAL_TERMINAL_INPUT = @as(c_int, 0x200);
     pub const CP_UTF8 = @as(c_int, 65001);
     pub const INPUT_RECORD = extern struct {


### PR DESCRIPTION
this is already defined in the zig stdlib 
https://github.com/ziglang/zig/blob/9f0d2f94175a131d965e86a6396f5ac508b27bf8/lib/std/os/windows.zig#L3692
which caused `error: ambiguous reference` on windows due to the `usingnamespace`