### PR TITLE
make work on zig 0.13.0

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -10,7 +10,7 @@ pub fn build(b: *Build) void {
     }).module("wcwidth");
 
     const linenoise = b.addModule("linenoise", .{
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
         .imports = &.{
             .{
                 .name = "wcwidth",
@@ -22,7 +22,7 @@ pub fn build(b: *Build) void {
     // Static library
     const lib = b.addStaticLibrary(.{
         .name = "linenoise",
-        .root_source_file = .{ .path = "src/c.zig" },
+        .root_source_file = b.path("src/c.zig"),
         .target = target,
         .optimize = optimize,
     });
@@ -33,7 +33,7 @@ pub fn build(b: *Build) void {
     // Tests
     const main_tests = b.addTest(.{
         .name = "main-tests",
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
     });
@@ -46,7 +46,7 @@ pub fn build(b: *Build) void {
     // Zig example
     var example = b.addExecutable(.{
         .name = "example",
-        .root_source_file = .{ .path = "examples/example.zig" },
+        .root_source_file = b.path("examples.example.zig"),
         .target = target,
         .optimize = optimize,
     });
@@ -63,8 +63,8 @@ pub fn build(b: *Build) void {
         .target = target,
         .optimize = optimize,
     });
-    c_example.root_module.addCSourceFile(.{ .file = .{ .path = "examples/example.c" } });
-    c_example.addIncludePath(.{ .path = "include" });
+    c_example.root_module.addCSourceFile(.{ .file = b.path("examples/example.c") });
+    c_example.addIncludePath(b.path("include"));
     c_example.linkLibC();
     c_example.linkLibrary(lib);
 

--- a/src/term.zig
+++ b/src/term.zig
@@ -5,7 +5,7 @@ const File = std.fs.File;
 const unsupported_term = [_][]const u8{ "dumb", "cons25", "emacs" };
 
 const is_windows = builtin.os.tag == .windows;
-const termios = if (!is_windows) std.os.termios else struct { inMode: w.DWORD, outMode: w.DWORD };
+const termios = if (!is_windows) std.posix.termios else struct { inMode: w.DWORD, outMode: w.DWORD };
 
 pub fn isUnsupportedTerm(allocator: std.mem.Allocator) bool {
     const env_var = std.process.getEnvVarOwned(allocator, "TERM") catch return false;
@@ -52,7 +52,7 @@ pub fn enableRawMode(in: File, out: File) !termios {
         _ = k32.SetConsoleOutputCP(w.CP_UTF8);
         return result;
     } else {
-        const orig = try std.os.tcgetattr(in.handle);
+        const orig = try std.posix.tcgetattr(in.handle);
         var raw = orig;
 
         raw.iflag.BRKINT = false;
@@ -74,7 +74,7 @@ pub fn enableRawMode(in: File, out: File) !termios {
         // raw.cc[std.os.VMIN] = 1;
         // raw.cc[std.os.VTIME] = 0;
 
-        try std.os.tcsetattr(in.handle, std.os.TCSA.FLUSH, raw);
+        try std.posix.tcsetattr(in.handle, std.posix.TCSA.FLUSH, raw);
 
         return orig;
     }
@@ -85,7 +85,7 @@ pub fn disableRawMode(in: File, out: File, orig: termios) void {
         _ = k32.SetConsoleMode(in.handle, orig.inMode);
         _ = k32.SetConsoleMode(out.handle, orig.outMode);
     } else {
-        std.os.tcsetattr(in.handle, std.os.TCSA.FLUSH, orig) catch {};
+        std.posix.tcsetattr(in.handle, std.posix.TCSA.FLUSH, orig) catch {};
     }
 }
 


### PR DESCRIPTION
This combines two changes:

* update `build.zig` to use `b.path`, since the LazyPath struct has changed
* update `std.os` to `std.posix` for termios (taken from #23 (but also see #25))

Getting the library to work under 0.13.0 will _also_ require updating `build.zig.zon` with the fixed version of the `wcwidth` dependency, once (if) https://github.com/joachimschmidt557/zig-wcwidth/pull/5 gets merged.

With these changes, and pointing my local clone to a fixed version of the `wcwidth` dependency, `zig build test` builds and runs cleanly.

Thank you for the library, and let me know if I can help get this across the line!