### PR TITLE
remove `k32.SetConsoleMode` declaration and rename `utf16leToUtf8`

### DIFF
--- a/src/term.zig
+++ b/src/term.zig
@@ -28,7 +28,6 @@ const w = struct {
 
 const k32 = struct {
     pub usingnamespace std.os.windows.kernel32;
-    pub extern "kernel32" fn SetConsoleMode(hConsoleHandle: w.HANDLE, dwMode: w.DWORD) callconv(w.WINAPI) w.BOOL;
     pub extern "kernel32" fn SetConsoleCP(wCodePageID: w.UINT) callconv(w.WINAPI) w.BOOL;
     pub extern "kernel32" fn PeekConsoleInputW(hConsoleInput: w.HANDLE, lpBuffer: [*]w.INPUT_RECORD, nLength: w.DWORD, lpNumberOfEventsRead: ?*w.DWORD) callconv(w.WINAPI) w.BOOL;
     pub extern "kernel32" fn ReadConsoleW(hConsoleInput: w.HANDLE, lpBuffer: [*]u16, nNumberOfCharsToRead: w.DWORD, lpNumberOfCharsRead: ?*w.DWORD, lpReserved: ?*anyopaque) callconv(w.WINAPI) w.BOOL;
@@ -183,7 +182,7 @@ fn readWin32Console(self: File, buffer: []u8) !usize {
             break :_ 2;
         } else 1;
         //WideCharToMultiByte(GetConsoleCP(), 0, buf, bufLen, converted, sizeof(converted), NULL, NULL);
-        utf8ConsoleReadBytes += try std.unicode.utf16leToUtf8(&utf8ConsoleBuffer, wideBuf[0..wideBufLen]);
+        utf8ConsoleReadBytes += try std.unicode.utf16LeToUtf8(&utf8ConsoleBuffer, wideBuf[0..wideBufLen]);
     }
     return buffer.len - toRead;
 }


### PR DESCRIPTION
Remove `pub extern "kernel32" fn SetConsoleMode` since it was added to Zig in [March](https://github.com/joachimschmidt557/linenoize/commit/e5d7e72c9a84645804660d24a54f805c17a5e7ae#diff-0f3b2a02531c2b655846180e5b0539b382cff6853451cf40344cc799baa77322R34) and that caused `error: ambiguous reference` on Windows.
Also rename `utf16leToUtf8` because it was [`deprecated; renamed to utf16LeToUtf8`](https://github.com/ziglang/zig/blob/master/lib/std/unicode.zig#L1068).