### PR TITLE
history: fix for std.ArrayListUnmanaged.pop() -> ?T

### DIFF
--- a/src/history.zig
+++ b/src/history.zig
@@ -50,7 +50,7 @@ pub const History = struct {
 
     /// Removes the last item (newest item) of the history
     pub fn pop(self: *Self) void {
-        self.allocator.free(self.hist.pop());
+        self.allocator.free(self.hist.pop().?);
     }
 
     /// Loads the history from a file


### PR DESCRIPTION
Fixes for the 0.14-dev change that pop() is what popOrNull() used to be.

```
$ zig version
0.14.0-dev.3188+34644511b
```