### PR TITLE
term.getColumns() - additional check to make sure the number of columns is never 0

### DIFF
--- a/src/term.zig
+++ b/src/term.zig
@@ -138,7 +138,7 @@ pub fn getColumns(in: File, out: File) !usize {
             };
 
             const err = std.posix.system.ioctl(in.handle, std.posix.T.IOCGWINSZ, @intFromPtr(&winsize));
-            if (std.posix.errno(err) == .SUCCESS) {
+            if (std.posix.errno(err) == .SUCCESS and winsize.col > 0) {
                 return winsize.col;
             } else {
                 return try getColumnsFallback(in, out);


### PR DESCRIPTION
When I run this library under qemu with the `-nographic` flag on top of the Linux kernel,  `winsize.col` equals to 0, so I get an "integer overflow" error in `state.zig` on line 253 `const avail_space = self.cols - display_prompt_width - display_hint_width - 1;` as both `self.cols` and `display_prompt_width` are equal to 0 resulting in  `const avail_space = 0 - 0 - 0 - 1;`.