### PR TITLE
API change: added initWithHandles() and print_newline

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -171,9 +171,8 @@ fn linenoiseEdit(ln: *Linenoise, in: File, out: File, prompt: []const u8) !?[]co
 /// Read a line with custom line editing mechanics. This includes hints,
 /// completions and history
 fn linenoiseRaw(ln: *Linenoise, in: File, out: File, prompt: []const u8) !?[]const u8 {
-    defer {
-        if (ln.print_newline)
-            out.writeAll("\n") catch {};
+    if (ln.print_newline) {
+        defer out.writeAll("\n") catch {};
     }
 
     const orig = try enableRawMode(in, out);
@@ -210,20 +209,13 @@ pub const Linenoise = struct {
 
     /// Initialize a linenoise struct
     pub fn init(allocator: Allocator) Self {
-        var self: Self = .{
-            .allocator = allocator,
-            .history = History.empty(allocator),
-            .stdin_file = std.io.getStdIn(),
-            .stdout_file = std.io.getStdOut(),
-        };
-        self.examineStdIo();
-        return self;
+        return initWithFiles(allocator, std.io.getStdIn(), std.io.getStdOut());
     }
 
     /// Initialize a linenoise struct with specific input and output streams
     /// Use this method to connect linenoise to the files of your choosing
     /// like /dev/tty on Linux or \\.\CONIN$ on Windows
-    pub fn initWithHandles(allocator: Allocator, input: std.fs.File, output: std.fs.File) Self {
+    pub fn initWithFiles(allocator: Allocator, input: std.fs.File, output: std.fs.File) Self {
         var self = Self{
             .allocator = allocator,
             .history = History.empty(allocator),

--- a/src/main.zig
+++ b/src/main.zig
@@ -203,6 +203,7 @@ pub const Linenoise = struct {
     completions_callback: ?CompletionsCallback = null,
     stdin_file: File,
     stdout_file: File,
+    /// Go to a new line after linenoise finishes (default is true)
     print_newline: bool = true,
 
     const Self = @This();
@@ -219,12 +220,15 @@ pub const Linenoise = struct {
         return self;
     }
 
-    pub fn initWithHandles(allocator: Allocator, input: std.fs.File.Handle, output: std.fs.File.Handle) Self {
+    /// Initialize a linenoise struct with specific input and output streams
+    /// Use this method to connect linenoise to the files of your choosing
+    /// like /dev/tty on Linux or \\.\CONIN$ on Windows
+    pub fn initWithHandles(allocator: Allocator, input: std.fs.File, output: std.fs.File) Self {
         var self = Self{
             .allocator = allocator,
             .history = History.empty(allocator),
-            .stdin_file = .{ .handle = input },
-            .stdout_file = .{ .handle = output },
+            .stdin_file = input,
+            .stdout_file = output,
         };
         self.examineStdIo();
         return self;

--- a/src/main.zig
+++ b/src/main.zig
@@ -171,8 +171,9 @@ fn linenoiseEdit(ln: *Linenoise, in: File, out: File, prompt: []const u8) !?[]co
 /// Read a line with custom line editing mechanics. This includes hints,
 /// completions and history
 fn linenoiseRaw(ln: *Linenoise, in: File, out: File, prompt: []const u8) !?[]const u8 {
-    if (ln.print_newline) {
-        defer out.writeAll("\n") catch {};
+    defer {
+        if (ln.print_newline)
+            out.writeAll("\n") catch {};
     }
 
     const orig = try enableRawMode(in, out);


### PR DESCRIPTION
I propose additions to API which will enable using `linenoize` in TUI applications, namely:

1. Add `initWithHandles(allocator, input, output)` — this will allow calling program to ingest data piped into default stdin stream, while displaying TUI on "/dev/tty" (or "\\\\.\\CONIN$" on Windows), like `less` tool does;
2. Add `print_newline` option — this will allow using this library in confined parts of the TUI, and let the program itself handle cursor position after `linenoise` finishes;

These changes should not affect existing programs, as they are only additions.'

p.s. this might help with https://github.com/joachimschmidt557/linenoize/issues/5